### PR TITLE
Fix route. Removed use of the missing function String.concat

### DIFF
--- a/lib/src/route.dart
+++ b/lib/src/route.dart
@@ -63,9 +63,12 @@ class Route {
     }
 
     var keys = [];
+    
+    if (!strict) {
+      path += '/?';
+    }
 
-    path = path.concat(strict ? '' : '/?')
-        .replaceAllMapped(new RegExp(r'(\.)?:(\w+)(\?)?'), (Match placeholder) {
+    path = path.replaceAllMapped(new RegExp(r'(\.)?:(\w+)(\?)?'), (Match placeholder) {
           var replace = new StringBuffer('(?:');
 
           if (placeholder[1] != null) {


### PR DESCRIPTION
In SDK version 27487 print error:
Class 'String' has no instance method 'concat'.
