### PR TITLE
Fixed param and payload methods to work with POST requests

### DIFF
--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -36,12 +36,16 @@ class Request {
   X509Certificate get certificate => _request.certificate;
 
   String param(String name) {
-    if (params.containsKey(name) && params[name] != null) {
-      return params[name];
+    var value;
+    value = params[name];
+    if (value != null) {
+      return value;
     }
-    return _request.uri.queryParameters[name] != null
-         ? _request.uri.queryParameters[name]
-         : '';
+    value = _request.uri.queryParameters[name];
+    if (value != null) {
+      return value;
+    }
+    return ''; // no parameter with name found
   }
 
   Future<Map> payload({ Encoding enc: UTF8 }) {

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -35,6 +35,17 @@ class Request {
 
   X509Certificate get certificate => _request.certificate;
 
+  /// Returns the value of the HTTP parameter with the given _name_.
+  ///
+  /// Returns the value of the named parameter from the query string or the
+  /// request body, or an empty string if the it is not defined.
+  ///
+  /// If the parameter is defined in both, the value from the request body is returned.
+  ///
+  /// Note: when processing POST requests, the [payload] method should be
+  /// called beforehand. Otherwise any parameters set in the request body
+  /// are ignored.
+
   String param(String name) {
     var value;
     value = params[name];
@@ -48,10 +59,18 @@ class Request {
     return ''; // no parameter with name found
   }
 
+  /// Parses the request body for query parameters.
+  ///
+  /// Used for handling POST requests. This method must be used
+  /// before [param] will return parameters from the request body,
+  /// otherwise it only examines the query string.
+  ///
+  /// Returns the parameters parsed as a [Map] of names and values.
+
   Future<Map> payload({ Encoding enc: UTF8 }) {
     var completer = new Completer();
     _request.transform(const AsciiDecoder()).listen((content) {
-      final params = new Map.fromIterable(
+      params = new Map.fromIterable(
           content.split('&').map((kvs) => kvs.split('=')),
           key: (kv) => Uri.decodeQueryComponent(kv[0], encoding: enc),
           value: (kv) => Uri.decodeQueryComponent(kv[1], encoding: enc)


### PR DESCRIPTION
Changed "final params" to just "params" inside the `payload` method, so it doesn't create a local variable called `params` instead of using the method variable of the same name.

I think this is the intention of the original code, because otherwise the member variable `params` serves no purpose.