### PR TITLE
Added support for parsing a JSON request payload

### DIFF
--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -84,6 +84,12 @@ class Request {
           }, onDone: () {
             completer.complete(payload);
           });
+    } else if (isMime('application/json')) {
+      _request.transform(const Utf8Decoder())
+          .listen((content) {
+            final payload = JSON.decode(content);
+            completer.complete(payload);
+          });
     }
     return completer.future;
   }


### PR DESCRIPTION
I was using this library and noticed it had no support for parsing the request body as JSON, so I thought I'd contribute my first take on it. I created a related issue at #68.

I'm super new to Dart, so let me know if there is any hardening you'd like to see.